### PR TITLE
Split models into separate files

### DIFF
--- a/models/BonusResult.v1.yaml
+++ b/models/BonusResult.v1.yaml
@@ -1,0 +1,36 @@
+title: Blessing Result
+description: Represents the outcome of a single blessing after the election.
+type: object
+properties:
+  id:
+    type: string
+    description: 'ID of the bonusResult object (usually UUID, not always)'
+  bonusId:
+    type: string
+    description: Internal blessing ID
+  bonusTitle:
+    type: string
+    description: Title of the blessing
+  teamId:
+    type: string
+    format: uuid
+    description: Team that won the blessing
+  totalVotes:
+    type: integer
+    description: Total votes cast towards this blessing
+  description:
+    type: string
+    description: Description of the blessing result
+  teamVotes:
+    type: integer
+    description: Votes cast by the winning team (present starting Season 2)
+    nullable: true
+  highestTeam:
+    type: string
+    format: uuid
+    description: 'Highest bidding team, ie. cast the most votes  (present starting Season 2)'
+    nullable: true
+  highestTeamVotes:
+    type: integer
+    description: Votes cast by the highest bidding team (present starting Season 2)
+    nullable: true

--- a/models/Bossfight.v1.yaml
+++ b/models/Bossfight.v1.yaml
@@ -1,0 +1,21 @@
+title: Boss Fight
+allOf:
+  - $ref: ./Game.v1.yaml
+  - type: object
+    properties:
+      awayHp:
+        type: string
+        description: Away team's remaining Team Spirit as a string
+      homeHp:
+        type: string
+        description: Home team's remaining Team Spirit as a string
+      awayMaxHp:
+        type: string
+        description: Away team's maximum Team Spirit as a string
+      homeMaxHp:
+        type: string
+        description: Home team's maximum Team Spirit as a string
+      damageResults:
+        type: string
+        description: Stringified object containing info for the current damage event
+description: Represents a boss fight (Day X)

--- a/models/CommunityChestProgress.v1.yaml
+++ b/models/CommunityChestProgress.v1.yaml
@@ -1,0 +1,13 @@
+type: object
+title: Community Chest
+properties:
+  runs:
+    type: string
+    description: String containing the number of runs so far this chest
+  progress:
+    type: string
+    description: String containing the percentage towards the next chest unlock
+  chestsUnlocked:
+    type: integer
+    description: Number of chests unlocked so far
+description: State of the Community Chest

--- a/models/DecreeResult.v1.yaml
+++ b/models/DecreeResult.v1.yaml
@@ -1,0 +1,21 @@
+title: Decree Result
+description: Represents the outcome message of a single passed decree after the election.
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+    description: ID of the decree result object
+  decreeId:
+    type: string
+    format: uuid
+    description: Internal ID of the decree
+  decreeTitle:
+    type: string
+    description: Decree title
+  description:
+    type: string
+    description: Decree result description
+  totalVotes:
+    type: integer
+    description: Total votes cast towards this decree

--- a/models/Division.v1.yaml
+++ b/models/Division.v1.yaml
@@ -1,0 +1,18 @@
+title: Division
+type: object
+description: A single team division (eg. Wild High or Chaotic Good)
+properties:
+  id:
+    type: string
+    format: uuid
+    description: ID of this division
+  name:
+    type: string
+    description: Name of this division
+    example: Wild High
+  teams:
+    type: array
+    description: IDs of teams in this division
+    items:
+      type: string
+      format: uuid

--- a/models/EventResult.v1.yaml
+++ b/models/EventResult.v1.yaml
@@ -1,0 +1,10 @@
+title: Event Result
+type: object
+properties:
+  id:
+    type: string
+    description: The internal ID of this event result
+  msg:
+    type: string
+    description: The message displayed on the Blaseball website
+description: Represents a general (usually story-related) event after the election.

--- a/models/FeedEvent.v1.yaml
+++ b/models/FeedEvent.v1.yaml
@@ -1,0 +1,69 @@
+title: Feed Event
+type: object
+description: An event in the feed.
+properties:
+  id:
+    type: string
+    format: uuid
+    description: ID of the event
+  playerTags:
+    type: array
+    description: List of players associated with the event
+    nullable: true
+    items:
+      type: string
+      format: uuid
+  teamTags:
+    type: array
+    description: List of teams associated with the event
+    nullable: true
+    items:
+      type: string
+      format: uuid
+  gameTags:
+    type: array
+    description: List of games associated with the event
+    nullable: true
+    items:
+      type: string
+      format: uuid
+  metadata:
+    type: object
+    nullable: true
+    description: Event-specific metadata
+  created:
+    type: string
+    format: date-time
+    description: Time the event occurred
+  season:
+    type: integer
+    default: -1
+    description: Season the event occurred in
+  tournament:
+    type: integer
+    default: -1
+    description: Tournament the event occurred in
+  type:
+    type: integer
+    description: Feed event type
+  day:
+    type: integer
+    description: Day the event occurred
+  phase:
+    type: integer
+    description: Game phase the event occurred in
+  category:
+    type: integer
+    description: |-
+      Event category
+      * 0: Game
+      * 1: Changes
+      * 2: Abilities
+      * 3: Outcomes
+      * 4: Narrative
+  description:
+    type: string
+    description: Event text
+  nuts:
+    type: integer
+    description: Number of upshells or herring on this event

--- a/models/Game.v1.yaml
+++ b/models/Game.v1.yaml
@@ -1,14 +1,14 @@
 type: object
-additionalProperties: false
-x-tags:
-  - Games
-title: Blaseball Game
-x-examples: {}
-description: ''
+title: Game
+description: A Game of Blaseball
 properties:
   id:
     type: string
     description: ID of this game
+  _id:
+    type: string
+    format: uuid
+    deprecated: true
   basesOccupied:
     type: array
     description: The indices of the currently occupied bases (zero-indexed)
@@ -54,6 +54,7 @@ properties:
     description: ID of the pitcher for the away team. `null` for future games.
   awayPitcherName:
     type: string
+    nullable: true
     description: Name of the pitcher for the away team. `null` for future games.
   awayBatter:
     type: string
@@ -83,12 +84,11 @@ properties:
   awayOdds:
     type: number
     description: Calculated odds of the away team winning. Zero for future games.
-    minimum: 0
-    maximum: 1
     format: double
   awayStrikes:
     type: integer
     description: The amount of strikes needed for the away team to strike out (usually 3)
+    nullable: true
     example: 3
   awayScore:
     type: number
@@ -103,6 +103,7 @@ properties:
     description: ID of the pitcher for the home team. `null` for future games.
   homePitcherName:
     type: string
+    nullable: true
     description: Name of the pitcher for the home team. `null` for future games.
   homeBatter:
     type: string
@@ -131,12 +132,11 @@ properties:
   homeOdds:
     type: number
     description: Calculated odds of the home team winning. Zero for future games.
-    minimum: 0
-    maximum: 1
     format: double
   homeStrikes:
     type: integer
     description: The amount of strikes needed for the home team to strike out (usually 3)
+    nullable: true
   homeScore:
     type: number
     description: Score of the home team
@@ -180,8 +180,6 @@ properties:
     type: integer
     description: |
       Current inning number (zero-indexed)
-    minimum: 0
-    example: 7
   topOfInning:
     type: boolean
     description: |
@@ -205,6 +203,7 @@ properties:
     description: Whether the away team has been shamed this game
   weather:
     type: integer
+    nullable: true
   baserunnerCount:
     type: integer
     description: Amount of players on base at the moment
@@ -281,9 +280,11 @@ properties:
     type: string
     description: Stadium that this game took place in
     nullable: true
+    format: uuid
   secretBaserunner:
     type: string
     nullable: true
+    format: uuid
   topInningScore:
     type: number
     description: Score for the top of this inning
@@ -304,75 +305,7 @@ properties:
     items: {}
   state:
     type: object
-required:
-  - id
-  - basesOccupied
-  - baseRunners
-  - baseRunnerNames
-  - outcomes
-  - terminology
-  - lastUpdate
-  - rules
-  - statsheet
-  - awayPitcher
-  - awayPitcherName
-  - awayBatter
-  - awayBatterName
-  - awayTeam
-  - awayTeamName
-  - awayTeamNickname
-  - awayTeamColor
-  - awayTeamEmoji
-  - awayOdds
-  - awayStrikes
-  - awayScore
-  - awayTeamBatterCount
-  - homePitcher
-  - homePitcherName
-  - homeBatter
-  - homeBatterName
-  - homeTeam
-  - homeTeamName
-  - homeTeamNickname
-  - homeTeamColor
-  - homeTeamEmoji
-  - homeOdds
-  - homeStrikes
-  - homeScore
-  - homeTeamBatterCount
-  - season
-  - isPostseason
-  - day
-  - phase
-  - gameComplete
-  - finalized
-  - gameStart
-  - halfInningOuts
-  - halfInningScore
-  - inning
-  - topOfInning
-  - atBatBalls
-  - atBatStrikes
-  - seriesIndex
-  - seriesLength
-  - shame
-  - weather
-  - baserunnerCount
-  - homeBases
-  - awayBases
-  - repeatCount
-  - awayTeamSecondaryColor
-  - homeTeamSecondaryColor
-  - homeBalls
-  - awayBalls
-  - homeOuts
-  - awayOuts
-  - playCount
-  - tournament
-  - baseRunnerMods
-  - homePitcherMod
-  - homeBatterMod
-  - awayPitcherMod
-  - awayBatterMod
-  - scoreUpdate
-  - scoreLedger
+  endPhase:
+    type: integer
+  newHalfInningPhase:
+    type: integer

--- a/models/GameStatsheet.v1.yaml
+++ b/models/GameStatsheet.v1.yaml
@@ -1,0 +1,36 @@
+title: Game Statsheet
+type: object
+description: |-
+  Represents the statsheet of a single game. This object doesn't include much information by itself, but refers to the team statsheets (which in turn refer to the player statsheets) containing most of the useful statistics.
+
+  In case of *Black Hole* or *Sun 2* weather, the runs by inning arrays may contain "negative runs" - 10 runs get subtracted from the runs for that inning, and adding up all the innings will still total the team's final score for that game.
+properties:
+  id:
+    type: string
+    description: ID of this game statsheet
+  homeTeamRunsByInning:
+    type: array
+    minItems: 8
+    description: Runs scored by the home team in each inning
+    items:
+      type: integer
+  awayTeamRunsByInning:
+    type: array
+    minItems: 9
+    description: Runs scored by the away team in each inning
+    items:
+      type: integer
+  awayTeamTotalBatters:
+    type: integer
+    description: Always 0 (broken?)
+  homeTeamTotalBatters:
+    type: integer
+    description: Always 0 (broken?)
+  awayTeamStats:
+    type: string
+    format: uuid
+    description: ID of the away team's statsheet for this game
+  homeTeamStats:
+    type: string
+    format: uuid
+    description: ID of the home team's statsheet for this game

--- a/models/GiftProgress.v1.yaml
+++ b/models/GiftProgress.v1.yaml
@@ -1,0 +1,32 @@
+type: object
+title: Gift Progress
+description: State of the league's gift giving.
+properties:
+  teamProgress:
+    type: object
+    description: Dictionary of team ID's to current number of gifts and progress to their next gift.
+    properties:
+      <team_id>:
+        type: object
+        properties:
+          total:
+            type: integer
+            description: Number of gifts earned
+          toNext:
+            type: number
+            description: Percentage to next gift
+  teamWishLists:
+    type: object
+    description: Dictionary of team ID's to an array of top wishlisted items.
+    properties:
+      <team_id>:
+        type: array
+        items:
+          type: object
+          properties:
+            bonus:
+              type: string
+              description: ID for a gift
+            percent:
+              type: number
+              description: Percentage of wishlist for this gift

--- a/models/GlobalEvents.v1.yaml
+++ b/models/GlobalEvents.v1.yaml
@@ -1,0 +1,17 @@
+type: array
+items:
+  type: object
+  properties:
+    id:
+      type: string
+      description: ID of this ticker message (not always a UUID)
+    msg:
+      type: string
+      description: Text of this message
+    expire:
+      type: string
+      format: date-time
+      description: Time this message expires (or null for indefinite)
+      nullable: true
+title: Global Events
+description: List of Ticker entries.

--- a/models/Idols.v1.yaml
+++ b/models/Idols.v1.yaml
@@ -1,0 +1,16 @@
+title: Idols
+type: object
+description: State of the Idol (MVP) Board
+properties:
+  data:
+    type: object
+    properties:
+      strictlyConfidential:
+        type: integer
+        description: Position of the MVP line (Noodle)
+  idols:
+    type: array
+    description: Sorted list of player IDs by number of idols
+    items:
+      type: string
+      format: uuid

--- a/models/Item.v1.yaml
+++ b/models/Item.v1.yaml
@@ -1,0 +1,96 @@
+title: Item
+type: object
+description: 'Represents a single item that can be held by a player, '
+properties:
+  id:
+    type: string
+    format: uuid
+  name:
+    type: string
+    description: Name of the Item
+  forger:
+    type: string
+    description: Unknown
+    nullable: true
+  forgerName:
+    type: string
+    description: Unknown
+    nullable: true
+  prePrefix:
+    type: object
+    description: Adjustments to add before the prefixes
+    nullable: true
+    properties:
+      name:
+        type: string
+      adjustments:
+        type: array
+        items:
+          type: object
+  prefixes:
+    type: array
+    description: Adjustments to add before the item name (eg. Wooden Bat)
+    nullable: true
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+        adjustments:
+          type: array
+          items:
+            type: object
+  postPrefix:
+    type: object
+    description: Adjustments to add before the item name buf after the prefix (eg. Traitor 'Head' Sunglasses)
+    nullable: true
+    properties:
+      name:
+        type: string
+      adjustments:
+        type: array
+        items:
+          type: object
+  root:
+    type: object
+    description: 'Base adjustment for this item (eg. Bat, Cap)'
+    properties:
+      name:
+        type: string
+      adjustments:
+        type: array
+        items:
+          type: object
+  suffix:
+    type: object
+    description: Adjustments to add after the item name (eg. Cape of Containment)
+    nullable: true
+    properties:
+      name:
+        type: string
+      adjustments:
+        type: array
+        items:
+          type: object
+  durability:
+    type: integer
+    description: Max health of this item
+  health:
+    type: integer
+    description: Current health of this item
+  baserunningRating:
+    type: number
+    nullable: true
+    description: Amount of baserunning to add overall
+  pitchingRating:
+    type: number
+    nullable: true
+    description: Amount of pitching to add overall
+  hittingRating:
+    type: number
+    nullable: true
+    description: Amount of hitting to add overall
+  defenseRating:
+    type: number
+    nullable: true
+    description: Amount of defense to add overall

--- a/models/League.v1.yaml
+++ b/models/League.v1.yaml
@@ -1,0 +1,22 @@
+title: League
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+    description: ID of the league
+  name:
+    type: string
+    description: Name of the league
+    example: Internet League Blaseball
+  subleagues:
+    type: array
+    description: IDs of subleagues in this league
+    items:
+      type: string
+      format: uuid
+  tiebreakers:
+    type: string
+    format: uuid
+    description: ID of the league's tiebreaker list
+description: The current Blaseball League (Internet League Blaseball)

--- a/models/Modification.v1.yaml
+++ b/models/Modification.v1.yaml
@@ -1,0 +1,36 @@
+title: Modification
+type: object
+description: Represents a Player, Team, Stadium, or League Modification.
+properties:
+  id:
+    type: string
+    description: ID of the modification
+  color:
+    type: string
+    description: Modification icon color
+  background:
+    type: string
+    description: Modification background color
+  textColor:
+    type: string
+    description: Modification text color
+  title:
+    type: string
+    description: Modification name
+  description:
+    type: string
+    description: Modification description
+  descriptions:
+    type: object
+    description: Modification descriptions for various uses.
+x-examples:
+  Fireproof:
+    id: FIREPROOF
+    color: "#a5c5f0"
+    textColor: "#a5c5f0"
+    background: "#4c77b0"
+    title: Fireproof
+    description: A Fireproof Player can not be incinerated.
+    descriptions:
+      player: This Player cannot be incinerated.
+      team: This Team and the Players on it cannot be incinerated.

--- a/models/OffseasonRecap.v1.yaml
+++ b/models/OffseasonRecap.v1.yaml
@@ -1,0 +1,52 @@
+title: Election Results
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+    description: ID of the offseasonRecap object
+  bonusResults:
+    type: array
+    description: IDs of blessing results
+    items:
+      type: string
+      format: uuid
+  decreeResults:
+    type: array
+    description: IDs of decree results (only passed decrees)
+    items:
+      type: string
+      format: uuid
+  name:
+    type: string
+    description: Name of the election
+  season:
+    type: integer
+    description: Season of this election (zero-indexed)
+  totalBonusVotes:
+    type: integer
+    description: Total votes cast towards blessings
+  totalDecreeVotes:
+    type: integer
+    description: Total votes cast towards decrees
+  voteCount:
+    type: integer
+    description: Total votes cast in this election
+  eventResults:
+    type: array
+    description: IDs of "event results" (listed as "Tidings") on the website
+    items:
+      type: string
+      format: uuid
+  willResults:
+    type: array
+    description: IDs of "will results". These do not map to any known IDs or endpoints
+    nullable: true
+    items:
+      type: string
+      format: uuid
+  totalWillVotes:
+    type: integer
+    description: Total votes cast towards wills
+    nullable: true
+description: Represents the outcome of an election.

--- a/models/OffseasonSetup.v1.yaml
+++ b/models/OffseasonSetup.v1.yaml
@@ -1,0 +1,109 @@
+title: Election Setup
+type: object
+description: 'Represents a selection of decrees, blessings, wills, or gifts available for a given election.'
+properties:
+  decrees:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Internal decree ID
+        type:
+          type: integer
+          description: Unknown
+        title:
+          type: string
+          description: Decree title
+        description:
+          type: string
+          description: Decree description
+        source:
+          type: integer
+          description: Unknown
+  blessings:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Internal blessing ID
+        type:
+          type: integer
+          description: Unknown
+        value:
+          type: integer
+          description: Unknown
+        title:
+          type: string
+          description: Blessing title
+        subheader:
+          type: string
+          description: Usually sponsor names
+        description:
+          type: string
+          description: Blessing description
+        metadata:
+          type: object
+          description: Metadata information for the particular blessing
+  decreesToPass:
+    type: integer
+    description: Amount of decrees that will pass
+  wills:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Internal will ID
+        title:
+          type: string
+          description: Will title
+        description:
+          type: string
+          description: Will description
+        info:
+          type: array
+          description: Information about will selection
+          items:
+            type: object
+            properties:
+              type:
+                type: integer
+                description: Unknown
+              description:
+                type: string
+                description: Description of will filter selection
+              filters:
+                type: object
+                description: Metadata information for the particular filter
+  willsToPass:
+    type: integer
+    description: Amount of wills that will pass per-team
+  gifts:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Internal gift ID
+        type:
+          type: integer
+          description: Unknown
+        title:
+          type: string
+          description: Gift title
+        value:
+          type: integer
+          description: Unknown
+        metadata:
+          type: object
+          description: Metadata information for the particular gift
+        description:
+          type: string
+          description: Gift description

--- a/models/Player.v1.yaml
+++ b/models/Player.v1.yaml
@@ -1,15 +1,15 @@
 type: object
-additionalProperties: false
-description: ''
-x-tags:
-  - Players
-title: Blaseball Player
-x-examples: {}
+description: A Blaseball Player
+title: Player
 properties:
   id:
     type: string
     format: uuid
     description: ID of this player
+  _id:
+    type: string
+    format: uuid
+    deprecated: true
   name:
     type: string
     description: Name of this player
@@ -17,9 +17,11 @@ properties:
   deceased:
     type: boolean
     description: Whether this player is deceased (incinerated)
+    nullable: true
   peanutAllergy:
     type: boolean
     description: Whether this player is allergic to peanuts
+    nullable: true
   baseThirst:
     type: number
     description: 'Baserunning stat: attempts to steal base'
@@ -98,6 +100,7 @@ properties:
   cinnamon:
     type: number
     description: Unknown
+    nullable: true
   pressurization:
     type: number
     description: Unknown
@@ -115,15 +118,19 @@ properties:
   ritual:
     type: string
     description: '"Pre-game ritual" on player page'
+    nullable: true
   coffee:
     type: integer
-    description: This player's preferred coffee type (docs pending)
+    description: This player's preferred coffee type
+    nullable: true
   blood:
     type: integer
-    description: This player's blood type (docs pending)
+    description: This player's blood type
+    nullable: true
   fate:
     type: integer
     description: Unknown?
+    nullable: true
   permAttr:
     type: array
     description: Permanent player attributes
@@ -180,63 +187,15 @@ properties:
     type: integer
     description: Player evolution state
   items:
-    type: array
     description: Player Items
+    type: array
     items:
-      $ref: ../reference/Blaseball-API.v1.yaml#/components/schemas/Item
+      oneOf:
+        - type: string
+          properties: {}
+        - $ref: ./Item.v1.yaml
   itemAttr:
     type: array
     description: Modification provided by Items
     items:
       type: string
-required:
-  - id
-  - name
-  - deceased
-  - peanutAllergy
-  - baseThirst
-  - continuation
-  - groundFriction
-  - indulgence
-  - laserlikeness
-  - anticapitalism
-  - chasiness
-  - omniscience
-  - tenaciousness
-  - watchfulness
-  - buoyancy
-  - divinity
-  - martyrdom
-  - moxie
-  - musclitude
-  - patheticism
-  - thwackability
-  - tragicness
-  - coldness
-  - overpowerment
-  - ruthlessness
-  - shakespearianism
-  - suppression
-  - unthwackability
-  - totalFingers
-  - cinnamon
-  - pressurization
-  - soul
-  - bat
-  - armor
-  - ritual
-  - coffee
-  - blood
-  - fate
-  - permAttr
-  - seasAttr
-  - weekAttr
-  - gameAttr
-  - hitStreak
-  - consecutiveHits
-  - hittingRating
-  - pitchingRating
-  - baserunningRating
-  - defenseRating
-  - leagueTeamId
-  - tournamentTeamId

--- a/models/PlayerStatsheet.v1.yaml
+++ b/models/PlayerStatsheet.v1.yaml
@@ -1,0 +1,96 @@
+title: Player Statsheet
+type: object
+description: |-
+  Represents the statsheet for a single player during a single game or season.
+
+  There are a few known issues with Player Statsheets:
+    - Season 1 statsheets do not have valid player names
+    - Statsheets for the first day of the season have all numbers doubled
+properties:
+  id:
+    type: string
+    format: uuid
+    description: The ID of this player statsheet
+  playerId:
+    type: string
+    format: uuid
+    description: The ID of the player this statsheet is for
+  teamId:
+    type: string
+    format: uuid
+    description: The ID of the team this player played on during this game
+  team:
+    type: string
+    description: The name of the team this player played on during this game
+  name:
+    type: string
+    description: The name of the player
+  atBats:
+    type: integer
+    description: 'Batters: amount of at bats during this game. Not entirely accurate.'
+  caughtStealing:
+    type: integer
+    description: 'Batters: amount of times caught stealing a base'
+  doubles:
+    type: integer
+    description: 'Batters: amount of doubles hit'
+  earnedRuns:
+    type: integer
+    description: 'Pitchers: amount of runs scored by opposing batters'
+  groundIntoDp:
+    type: integer
+    description: 'Batters: amount of ground outs into double plays hit'
+  hits:
+    type: integer
+    description: 'Batters: amount of hits (of any type)'
+  hitsAllowed:
+    type: integer
+    description: 'Pitchers: amount of hits allowed to opposing batters'
+  homeRuns:
+    type: integer
+    description: 'Batters: amount of home runs scored'
+  losses:
+    type: integer
+    description: '1 if the team lost this game, 0 otherwise'
+  outsRecorded:
+    type: integer
+    description: 'Pitchers: the amount of outs this pitcher has thrown the opposing team (27 in a full game)'
+  rbis:
+    type: integer
+    description: 'Batters: amount of runs batted in (includes home runs)'
+  runs:
+    type: integer
+    description: 'Batters: amount of runs scored (any type)'
+  stolenBases:
+    type: integer
+    description: 'Batters: amount of bases stolen'
+  strikeouts:
+    type: integer
+    description: 'Pitchers: amount of times this pitcher has struck out the opposing batter'
+  struckouts:
+    type: integer
+    description: 'Batters: amount of times struck out'
+  triples:
+    type: integer
+    description: 'Batters: amount of triples hit'
+  walks:
+    type: integer
+    description: 'Batters: amount of walks drawn'
+  walksIssued:
+    type: integer
+    description: 'Pitchers: amount of walks issued to opposing batters'
+  wins:
+    type: integer
+    description: '1 if the team won this game, 0 otherwise'
+  hitByPitch:
+    type: integer
+    description: 'Batters: amount of times hit by pitch'
+  hitBatters:
+    type: integer
+    description: 'Pitchers (Jaylen): amount of batters hit by pitch'
+  quadruples:
+    type: integer
+    description: 'Batters: amount of quadruples hit (only relevant with 5th base)'
+  pitchesThrown:
+    type: integer
+    description: 'Pitchers: the amount of pitches thrown'

--- a/models/PlayoffMatchup.v1.yaml
+++ b/models/PlayoffMatchup.v1.yaml
@@ -1,0 +1,33 @@
+title: Playoff Matchup
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+  name:
+    type: string
+    nullable: true
+  awaySeed:
+    type: integer
+    nullable: true
+  awayTeam:
+    type: string
+    format: uuid
+    nullable: true
+    description: Team ID for away team
+  awayWins:
+    type: integer
+  homeSeed:
+    type: integer
+  homeTeam:
+    type: string
+    format: uuid
+  homeWins:
+    type: integer
+  gamesPlayed:
+    type: integer
+    description: ''
+  gamesNeeded:
+    type: string
+    description: Wins needed to progress
+description: 'A single playoff matchup (IE: one series of games)'

--- a/models/PlayoffRound.v1.yaml
+++ b/models/PlayoffRound.v1.yaml
@@ -1,0 +1,40 @@
+title: Playoff Round
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+  games:
+    type: array
+    description: List of list of games IDs for each gameday
+    items:
+      type: string
+  name:
+    type: string
+    example: Round 1
+  special:
+    type: boolean
+    description: 'True if special round (Internet League Series, etc)'
+  winners:
+    type: array
+    description: List of Team IDs that are progressing to the next round
+    items:
+      type: string
+      format: uuid
+  matchups:
+    type: array
+    description: List of PlayoffMatchups
+    items:
+      type: string
+      format: uuid
+  gameIndex:
+    type: integer
+    description: Current index into the `games` list
+  roundNumber:
+    type: integer
+  winnerSeeds:
+    type: array
+    description: Seeds for each element in `winners`
+    items:
+      type: integer
+description: A single playoff round (eg. Round 3 or The Internet League Series)

--- a/models/Playoffs.v1.yaml
+++ b/models/Playoffs.v1.yaml
@@ -1,0 +1,35 @@
+title: Playoffs
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+  name:
+    type: string
+    example: Postseason 12
+  numberOfRounds:
+    type: integer
+    description: Total number of playoff rounds
+  playoffDay:
+    type: integer
+    description: ''
+  rounds:
+    type: array
+    description: List of PlayoffRound IDs
+    items:
+      type: string
+      format: uuid
+  season:
+    type: integer
+  tomorrowRound:
+    type: integer
+    description: Playoff round for the next gameday
+  winner:
+    type: string
+    format: uuid
+    nullable: true
+    description: Team ID of playoff winner
+  tournament:
+    type: integer
+    description: Tournament ID (or -1 if not a tournament)
+description: A single playoff bracket

--- a/models/Renovation.v1.yaml
+++ b/models/Renovation.v1.yaml
@@ -1,0 +1,33 @@
+title: Renovation
+type: object
+description: Represents an available Stadium renovation to build
+properties:
+  id:
+    type: string
+  title:
+    type: string
+    description: Name of renovation
+  type:
+    type: integer
+  effects:
+    type: array
+    items:
+      type: string
+  description:
+    type: string
+    description: Description of renovation
+  data:
+    type: object
+    description: Metadata information about this renovation
+x-examples:
+  Big Buckets:
+    id: big_bucket_mod
+    title: Big Buckets
+    type: 1
+    effects:
+      - Modification
+    description: Place Big Buckets in Home Run territory to make your Home Runs just a little bit bigger.
+    data:
+      mod: BIG_BUCKET
+      addMsg: 'The {tnn} placed Big Buckets in the Home Run territory of {snn}.'
+      rmvMsg: 'The {tnn} removed Big Buckets from the Home Run territory of {snn}.'

--- a/models/RenovationProgress.v1.yaml
+++ b/models/RenovationProgress.v1.yaml
@@ -1,0 +1,24 @@
+type: object
+title: Renovation Progress
+description: Progress towards stadium renovations for a midseason
+properties:
+  stats:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID of the renovation
+        percent:
+          type: string
+          description: Percentage of gift contributions for this reno
+  progress:
+    type: object
+    properties:
+      total:
+        description: Number of renovations funded
+        type: integer
+      toNext:
+        description: Percentage progress to next renovation
+        type: number

--- a/models/Season.v1.yaml
+++ b/models/Season.v1.yaml
@@ -1,0 +1,33 @@
+title: Season
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+  league:
+    type: string
+    format: uuid
+    description: League ID
+  rules:
+    type: string
+    format: uuid
+    description: Unknown
+  schedule:
+    type: string
+    format: uuid
+    description: Unknown
+  seasonNumber:
+    type: integer
+  standings:
+    type: string
+    format: uuid
+    description: Standings ID
+  stats:
+    type: string
+    format: uuid
+    description: SeasonStatSheet ID
+  terminology:
+    type: string
+    format: uuid
+    description: Unknown
+description: A single season

--- a/models/SeasonStatsheet.v1.yaml
+++ b/models/SeasonStatsheet.v1.yaml
@@ -1,0 +1,12 @@
+title: Season Statsheet
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+  teamStats:
+    type: array
+    items:
+      type: string
+      format: uuid
+description: 'Represents the statsheet of a whole season. This object doesn''t include much information by itself, but refers to the team statsheets (which in turn refer to the player statsheets) containing most of the useful statistics.'

--- a/models/ShopSetup.v1.yaml
+++ b/models/ShopSetup.v1.yaml
@@ -1,0 +1,25 @@
+type: object
+title: Shop Info
+description: 'Information on availability, price, and payout of snacks in the shop'
+properties:
+  menu:
+    type: array
+    description: An array of available snacks
+    items:
+      type: string
+      format: uuid
+  snackData:
+    type: object
+    description: A dictionary with each entry being an array containing objects containing the price and payout for the stnack at that level.
+    properties:
+      <snack_name>Tiers:
+        type: array
+        items:
+          type: object
+          properties:
+            price:
+              type: integer
+              description: Cost of this tier of item
+            amount:
+              type: integer
+              description: Payout for this tier of item

--- a/models/Sim.v1.yaml
+++ b/models/Sim.v1.yaml
@@ -1,0 +1,175 @@
+title: Simulation Data
+type: object
+additionalProperties: false
+description: Global state data for the sim and frontend
+properties:
+  id:
+    type: string
+    example: thisidisstaticyo
+    description: Always "thisidisstaticyo"
+  day:
+    type: integer
+    description: Current game day
+    example: 6
+  season:
+    type: integer
+    description: Current game season
+    minimum: 0
+  phase:
+    type: integer
+    example: 0
+    description: Current phase of the league (See `Simulation phases`)
+  attr:
+    type: array
+    description: 'Various attributes, major league events, and unlocks. Often used as "feature flags" in the frontend code.'
+    example:
+      - OPENED_BOOK
+      - UNLOCKED_PEANUTS
+      - EAT_THE_RICH
+      - UNLOCKED_INTERVIEWS
+      - UNLOCKED_IDOLS
+      - PARTY_TIME
+      - UNLOCKED_HALL
+    items:
+      type: string
+  menu:
+    type: string
+    description: ''
+  rules:
+    type: string
+    format: uuid
+    description: Unknown
+  terminology:
+    type: string
+    format: uuid
+    description: Unknown
+  league:
+    type: string
+    format: uuid
+    description: ID of the current league object
+  seasonId:
+    type: string
+    format: uuid
+    description: ID of the season object
+  state:
+    description: Unknown
+    type: object
+  nextElectionEnd:
+    type: string
+    format: date-time
+    description: Time when the current election ends
+    deprecated: true
+  nextPhaseTime:
+    type: string
+    format: date-time
+    description: Time the next game phase starts (very unreliable)
+  nextSeasonStart:
+    type: string
+    format: date-time
+    description: Time when next season starts
+    deprecated: true
+  eraColor:
+    type: string
+    description: Theme color of the current game era
+    example: '#ff0000'
+    nullable: true
+  eraTitle:
+    type: string
+    example: The Discipline Era
+    description: Name of the current game era (displayed in the Blaseball.com page header)
+  subEraColor:
+    type: string
+    example: '#5988FF'
+    description: Theme color of the current game sub-era
+    nullable: true
+  subEraTitle:
+    type: string
+    description: Name of the current game sub-era (displayed in the Blaseball.com page header)
+    example: Rest in Violence
+  playoffs:
+    description: ID or list of current playoffs object(s)
+    oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        deprecated: true
+  playOffRound:
+    type: integer
+    description: 'Current round of playoffs (zero-indexed, 0 if not in playoffs)'
+    deprecated: true
+  twgo:
+    type: string
+    description: Concatenated initials of every player incinerated between Season 2 and Season 6
+    example: JHFMTOJMNPSMLMDGFOSEZDTMJWHPADAACGRTBBPBBCJRTPMJCSNKKAOMVMSTAJTVTCJIMPSSSTBFHRSSMSDKIRLWLVWSSMEIMCCDMDRTEIFBCLRMMW
+    deprecated: true
+  agitations:
+    type: integer
+    description: Amount of Black Hole game events (including Season 10 finals). In Season 11 this also counted Sun2 game events.
+  salutations:
+    type: integer
+    description: Amount of Sun2 game events (excluding Season 11)
+  tournament:
+    type: integer
+    description: 'Identifier of current exibition tournament, or -1'
+  tournamentRound:
+    type: integer
+    description: Current round of an active exibtion tournament (if applicable)
+  godsDayDate:
+    type: string
+    format: date-time
+  preseasonDate:
+    type: string
+    format: date-time
+  earlseasonDate:
+    type: string
+    format: date-time
+  earlsiestaDate:
+    type: string
+    format: date-time
+  midseasonDate:
+    type: string
+    format: date-time
+  latesiestaDate:
+    type: string
+    format: date-time
+  lateseasonDate:
+    type: string
+    format: date-time
+  endseasonDate:
+    type: string
+    format: date-time
+  earlpostseasonDate:
+    type: string
+    format: date-time
+  latepostseasonDate:
+    type: string
+    format: date-time
+  electionDate:
+    type: string
+    format: date-time
+  __v:
+    type: integer
+    deprecated: true
+  _id:
+    type: string
+    format: uuid
+    deprecated: true
+  openedBook:
+    type: boolean
+    deprecated: true
+  unlockedPeanuts:
+    type: boolean
+    deprecated: true
+  doTheThing:
+    type: boolean
+    deprecated: true
+  eatTheRich:
+    type: boolean
+    deprecated: true
+  unlockedInterviews:
+    type: boolean
+    deprecated: true
+  labourOne:
+    type: integer
+    deprecated: true

--- a/models/Stadium.v1.yaml
+++ b/models/Stadium.v1.yaml
@@ -1,0 +1,81 @@
+title: Stadium
+type: object
+description: Represents a team's stadium.
+x-tags:
+  - Models
+properties:
+  id:
+    type: string
+    format: uuid
+  hype:
+    type: number
+    description: 'Amount of hype in the stadium, if Hype Train is available'
+  mods:
+    type: array
+    description: List of modifications for this stadium
+    items:
+      type: string
+  name:
+    type: string
+    description: Full stadium name
+  birds:
+    type: integer
+    description: Number of birds in this stadium via Birdhouses (or negative from popped baloons)
+  model:
+    type: integer
+    description: Model of stadium
+  state:
+    type: object
+    description: Other state information
+  teamId:
+    type: string
+    format: uuid
+    description: Team this stadium
+  renoLog:
+    type: object
+  weather:
+    type: object
+    description: Weathers this stadium has build renovations for
+  nickname:
+    type: string
+    description: Stadium Nickname
+  renoCost:
+    type: integer
+  renoHand:
+    type: array
+    description: Currently available renovations
+    items:
+      type: string
+  mainColor:
+    type: string
+  mysticism:
+    type: number
+  viscosity:
+    type: number
+  elongation:
+    type: number
+  filthiness:
+    type: number
+  obtuseness:
+    type: number
+  forwardness:
+    type: number
+  grandiosity:
+    type: number
+  ominousness:
+    type: number
+  renoDiscard:
+    type: array
+    description: List of renovations that were not passed
+    items:
+      type: string
+  fortification:
+    type: number
+  inconvenience:
+    type: number
+  luxuriousness:
+    type: number
+  tertiaryColor:
+    type: string
+  secondaryColor:
+    type: string

--- a/models/Standings.v1.yaml
+++ b/models/Standings.v1.yaml
@@ -1,0 +1,19 @@
+type: object
+title: Standings
+properties:
+  id:
+    type: string
+    format: uuid
+  losses:
+    type: object
+    description: Number of regular season games lost for each team
+  wins:
+    type: object
+    description: Number of regular season Wins (physical objects) for each team
+  runs:
+    type: object
+    description: Number of regular season runs earned for each team
+  gamesPlayed:
+    type: object
+    description: Number of regular season games played for each team
+description: League standings for the regular season

--- a/models/Stream.v1.yaml
+++ b/models/Stream.v1.yaml
@@ -1,0 +1,103 @@
+title: Stream
+type: object
+description: Data returned by the SSE Event Stream
+properties:
+  value:
+    type: object
+    properties:
+      games:
+        type: object
+        properties:
+          sim:
+            $ref: ./Sim.v1.yaml
+          season:
+            $ref: ./Season.v1.yaml
+          schedule:
+            type: array
+            description: List of games for the current gameday
+            items:
+              $ref: ./Game.v1.yaml
+          standings:
+            $ref: ./Standings.v1.yaml
+          postseason:
+            type: object
+            deprecated: true
+          postseasons:
+            type: array
+            items:
+              type: object
+              properties:
+                round:
+                  $ref: ./PlayoffRound.v1.yaml
+                matchups:
+                  type: array
+                  description: Playoff matchups for the current gameday
+                  items:
+                    $ref: ./PlayoffMatchup.v1.yaml
+                playoffs:
+                  $ref: ./Playoffs.v1.yaml
+                allRounds:
+                  type: array
+                  items:
+                    $ref: ./PlayoffRound.v1.yaml
+                allMatchups:
+                  type: array
+                  items:
+                    $ref: ./PlayoffMatchup.v1.yaml
+                tomorrowRound:
+                  $ref: ./PlayoffRound.v1.yaml
+                tomorrowMatchups:
+                  type: array
+                  description: Playoff matchups for the next gameday
+                  items:
+                    $ref: ./PlayoffMatchup.v1.yaml
+          tomorrowSchedule:
+            type: array
+            description: List of games for the following gameday
+            items:
+              $ref: ./Game.v1.yaml
+          tournament:
+            $ref: ./Tournament.v1.yaml
+      leagues:
+        type: object
+        properties:
+          stats:
+            type: object
+            properties:
+              sunsun:
+                $ref: ./SunSun.v1.yaml
+              communityChest:
+                $ref: ./CommunityChestProgress.v1.yaml
+          teams:
+            type: array
+            items:
+              $ref: ./Team.v1.yaml
+          leagues:
+            type: array
+            items:
+              $ref: ./League.v1.yaml
+          stadiums:
+            type: array
+            items:
+              $ref: ./Stadium.v1.yaml
+          divisions:
+            type: array
+            items:
+              $ref: ./Division.v1.yaml
+          subleagues:
+            type: array
+            items:
+              $ref: ./Subleague.v1.yaml
+          tiebreakers:
+            type: array
+            items:
+              $ref: ./Tiebreakers.v1.yaml
+      temporal:
+        $ref: ./Temporal.v1.yaml
+      fights:
+        type: object
+        properties:
+          bossFights:
+            type: array
+            items:
+              $ref: ./Bossfight.v1.yaml

--- a/models/Subleague.v1.yaml
+++ b/models/Subleague.v1.yaml
@@ -1,0 +1,18 @@
+title: Subleague
+type: object
+properties:
+  id:
+    type: string
+    example: aabc11a1-81af-4036-9f18-229c759ca8a9
+    description: ID of this subleague
+  name:
+    type: string
+    description: Name of this subleague
+    example: The Wild League
+  divisions:
+    type: array
+    description: IDs of divisions in this subleague
+    items:
+      type: string
+      format: uuid
+description: A single team subleague (eg. Wild League or Good League)

--- a/models/SunSun.v1.yaml
+++ b/models/SunSun.v1.yaml
@@ -1,0 +1,12 @@
+type: object
+title: Sun(Sun) Status
+properties:
+  current:
+    type: number
+    description: Current value of sun(sun)
+  maxium:
+    type: number
+    description: Maximum value of sun(sun)
+  recharge:
+    type: number
+    description: Seasonal recharge amount of sun(sun)

--- a/models/Team.v1.yaml
+++ b/models/Team.v1.yaml
@@ -1,15 +1,15 @@
 type: object
-additionalProperties: false
-description: ''
-x-tags:
-  - Teams
-title: Blaseball Team
-x-examples: {}
+description: A Blaseball Team
+title: Team
 properties:
   id:
     type: string
     format: uuid
     description: ID of this team
+  _id:
+    type: string
+    format: uuid
+    deprecated: true
   lineup:
     type: array
     description: List of players in the lineup (batters)
@@ -25,12 +25,20 @@ properties:
   bullpen:
     type: array
     description: 'List of players in the bullpen (FK, aka. "Shadows")'
+    deprecated: true
     items:
       type: string
       format: uuid
   bench:
     type: array
     description: 'List of players on the bench (FK, aka. "Shadows")'
+    deprecated: true
+    items:
+      type: string
+      format: uuid
+  shadows:
+    type: array
+    description: List of players in the shadows
     items:
       type: string
       format: uuid
@@ -104,7 +112,7 @@ properties:
     description: Unknown what this does. Seemingly related to boss fights.
   card:
     type: integer
-    description: 'The tarot card this team won in the Season 11 elections, zero-indexed (eg. VII The Chariot is `6`). Teams with no tarot card (eg. Crabs) have a value of -1.'
+    description: "The tarot card this team, zero-indexed (eg. VII The Chariot is `6`). -1 is 'Fool', -2 is '-----'."
   tournamentWins:
     type: integer
     description: Number of tournament wins
@@ -112,6 +120,11 @@ properties:
     type: string
     description: Stadium ID
     nullable: true
+  imPosition:
+    type: array
+    description: Position on the depth chart
+    items:
+      type: number
   eDensity:
     type: number
     description: Current Team eDensity
@@ -127,30 +140,9 @@ properties:
     type: integer
     description: 'Current team level (Low C, AAAAA, etc)'
     nullable: true
-required:
-  - id
-  - lineup
-  - rotation
-  - bullpen
-  - bench
-  - fullName
-  - location
-  - mainColor
-  - nickname
-  - secondaryColor
-  - shorthand
-  - emoji
-  - slogan
-  - shameRuns
-  - totalShames
-  - totalShamings
-  - seasonShames
-  - seasonShamings
-  - championships
-  - rotationSlot
-  - weekAttr
-  - gameAttr
-  - seasAttr
-  - permAttr
-  - teamSpirit
-  - card
+  underchampionships:
+    type: integer
+    description: Amount of ILB underchampionships this team has won
+  deceased:
+    type: boolean
+    description: Whether this team is deceased (incinerated)

--- a/models/TeamElectionStats.v1.yaml
+++ b/models/TeamElectionStats.v1.yaml
@@ -1,0 +1,15 @@
+type: object
+title: Team Election Stats
+description: Information about a team's election contributions
+properties:
+  wills:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID of a will
+        percent:
+          type: string
+          description: Percentage of this team's will votes for this will

--- a/models/TeamStatsheet.v1.yaml
+++ b/models/TeamStatsheet.v1.yaml
@@ -1,0 +1,41 @@
+
+
+title: Team Statsheet
+type: object
+description: |-
+  Represents the statsheet for a single team during a single game.
+
+  The list of player statsheets are in order of player appearance in the game. If this is the home team, the first item will be the pitcher (as the pitcher is the first relevant player when the away team is batting).
+
+  There are a few known issues with Team Statsheets:
+   - Players that change their name mid-game (scattered, etc) will have 2 statsheets.
+   - Both pitchers will appear for each team, the correct one should have valid `outsRecorded` or `walksIssued` values.
+   - The number of pitches thrown is attributed to the wrong pitcher.
+   - Any player that makes a play will be included, including Ghosts.
+properties:
+  id:
+    type: string
+    format: uuid
+    description: ID of this team statsheet
+  playerStats:
+    type: array
+    description: List of player statsheets - at least one for each player that's played in this game for this team.
+    items:
+      type: string
+      format: uuid
+  gamesPlayed:
+    type: integer
+    description: Always 0 (broken?)
+  wins:
+    type: integer
+    description: Always 0 (broken?)
+  losses:
+    type: integer
+    description: Always 0 (broken?)
+  name:
+    type: string
+    description: Name of the team this statsheet is for
+  teamId:
+    type: string
+    format: uri
+    description: ID of the team this statsheet is for

--- a/models/Temporal.v1.yaml
+++ b/models/Temporal.v1.yaml
@@ -1,0 +1,38 @@
+title: Temporal
+type: object
+description: 'Contains miscellaneous (usually story-related) data sent through the stream data. Most significant use is transmitting "site takeover" text (eg. the site announcement, Peanut, Hall Monitor, or Boss speaking - including during boss fights).'
+properties:
+  doc:
+    type: object
+    properties:
+      id:
+        type: string
+        example: whatistime
+        description: Always "whatistime"
+      alpha:
+        type: integer
+        description: 'Amount of peanuts that can be bought at once in the store. Fluctuated a lot during Season 3, but has been set to 1000 since.'
+      beta:
+        type: integer
+        description: Maximum tier of squirrel in the store. Currently 1 (one tier only).
+      gamma:
+        type: integer
+        description: '-1 if the "Site Announcer" is speaking, 0 if the Peanut is speaking, 1 if the Hall Monitor is speaking, 2 if the Boss is speaking, has historically been 500000000'
+      delta:
+        type: boolean
+        description: Whether to show sponsor item in the store
+      epsilon:
+        type: boolean
+        description: Whether a "site takeover" is currently happening. Is (mostly) `false` during active bossfights despite text being displayed.
+      zeta:
+        type: string
+        description: 'Text currently being said by the "site takeover" speaker. This includes the Peanut''s flavor text during boss fights, even though `epsilon` is `false` during them.'
+      eta:
+        type: integer
+        description: How many games the Crabs have won (seen through the Telescope). Added mid-Season 11.
+      theta:
+        type: string
+        description: Unknown function. Currently an empty string. Added mid-Season 11.
+      iota:
+        description: Unknown function. Currently zero. Added mid-Season 11.
+        type: integer

--- a/models/Tiebreakers.v1.yaml
+++ b/models/Tiebreakers.v1.yaml
@@ -1,0 +1,14 @@
+title: Tiebreakers
+type: object
+properties:
+  id:
+    type: string
+    description: ID of this tiebreaker object
+    format: uuid
+  order:
+    type: array
+    description: List of teams in their tiebreaker order
+    items:
+      type: string
+      format: uuid
+description: The order of teams for use in tiebreaker situations

--- a/models/Tournament.v1.yaml
+++ b/models/Tournament.v1.yaml
@@ -1,0 +1,24 @@
+title: Tournament
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+  name:
+    type: string
+  index:
+    type: integer
+    description: Tournament identifier
+  teams:
+    type: array
+    description: Teams participating in the tournament
+    items:
+      type: string
+  playoffs:
+    type: string
+    format: uuid
+    description: Playoffs ID for tournament
+  finalsName:
+    type: string
+  description:
+    type: string

--- a/models/Tributes.v1.yaml
+++ b/models/Tributes.v1.yaml
@@ -1,0 +1,26 @@
+title: Tributes
+type: object
+properties:
+  teams:
+    type: array
+    items:
+      type: object
+      properties:
+        teamId:
+          type: string
+          format: uuid
+        peanuts:
+          type: integer
+          description: Number of peanuts payed in tribute
+  players:
+    type: array
+    items:
+      type: object
+      properties:
+        playerId:
+          type: string
+          format: uuid
+        peanuts:
+          type: integer
+          description: Number of peanuts payed in tribute
+description: State of the Hall of Flame


### PR DESCRIPTION
Move models into files so that we can call them from separate APIs without having to redefine them. Doesn't currently update the APIs to use them yet, that can be a different PR if needed.

On hold to merge until Stoplight fixes a bug where they don't support nested arrays so we can accurately define StreamData.